### PR TITLE
Changed boomer import type.

### DIFF
--- a/boom.go
+++ b/boom.go
@@ -25,7 +25,7 @@ import (
 	"runtime"
 	"strings"
 
-	"./boomer"
+	"boom/boomer"
 )
 
 const (


### PR DESCRIPTION
If relative paths are used while importing, go will through following error:
local import "./boomer" in non-local package
To avoid it, it's better to import w.r.t to the parent directory itself.
